### PR TITLE
Start migration of generated code into modules and away from raw strings

### DIFF
--- a/ensureRequiredSecurityHandlersExist.js
+++ b/ensureRequiredSecurityHandlersExist.js
@@ -1,0 +1,9 @@
+module.exports = (requiredSecurityHandlers) => {
+  for (let i = 0, ilen = requiredSecurityHandlers.length; i < ilen; i++) {
+    let requiredSecurityHandler = requiredSecurityHandlers[i];
+    if (typeof securityHandlers[requiredSecurityHandler] !== 'function') {
+      throw new Error('Expected to see a security handler for scheme "' +
+          requiredSecurityHandler + '" in options.securityHandlers');
+    }
+  }
+};

--- a/handleSecurity.js
+++ b/handleSecurity.js
@@ -1,0 +1,16 @@
+module.exports = (security, headers, params, operationId) => {
+  for (let i = 0, ilen = security.length; i < ilen; i++) {
+    let scheme = security[i];
+    let schemeParts = Object.keys(scheme);
+    for (let j = 0, jlen = schemeParts.length; j < jlen; j++) {
+      let schemePart = schemeParts[j];
+      let fulfilsSecurityRequirements = securityHandlers[schemePart](
+          headers, params, schemePart);
+      if (fulfilsSecurityRequirements) {
+        return;
+      }
+
+    }
+  }
+  throw new Error('No security scheme was fulfilled by the provided securityHandlers for operation ' + operationId);
+};

--- a/test/fixtures/api-wide-security/output.js
+++ b/test/fixtures/api-wide-security/output.js
@@ -21,8 +21,7 @@ function createApi(options) {
     }
     throw new Error('No security scheme was fulfilled by the provided securityHandlers for operation ' + operationId);
   };
-  const ensureRequiredSecurityHandlersExist = () => {
-    let requiredSecurityHandlers = ['api_wide_auth'];
+  const ensureRequiredSecurityHandlersExist = (requiredSecurityHandlers) => {
     for (let i = 0, ilen = requiredSecurityHandlers.length; i < ilen; i++) {
       let requiredSecurityHandler = requiredSecurityHandlers[i];
       if (typeof securityHandlers[requiredSecurityHandler] !== 'function') {
@@ -31,7 +30,7 @@ function createApi(options) {
       }
     }
   };
-  ensureRequiredSecurityHandlersExist();
+  ensureRequiredSecurityHandlersExist(['api_wide_auth']);
   const buildQuery = (obj) => {
     return Object.keys(obj)
       .filter(key => typeof obj[key] !== 'undefined')

--- a/test/fixtures/operation-security-overriding-api-wide-security-with-empty-security/output.js
+++ b/test/fixtures/operation-security-overriding-api-wide-security-with-empty-security/output.js
@@ -21,8 +21,7 @@ function createApi(options) {
     }
     throw new Error('No security scheme was fulfilled by the provided securityHandlers for operation ' + operationId);
   };
-  const ensureRequiredSecurityHandlersExist = () => {
-    let requiredSecurityHandlers = ['api_wide_auth'];
+  const ensureRequiredSecurityHandlersExist = (requiredSecurityHandlers) => {
     for (let i = 0, ilen = requiredSecurityHandlers.length; i < ilen; i++) {
       let requiredSecurityHandler = requiredSecurityHandlers[i];
       if (typeof securityHandlers[requiredSecurityHandler] !== 'function') {
@@ -31,7 +30,7 @@ function createApi(options) {
       }
     }
   };
-  ensureRequiredSecurityHandlersExist();
+  ensureRequiredSecurityHandlersExist(['api_wide_auth']);
   const buildQuery = (obj) => {
     return Object.keys(obj)
       .filter(key => typeof obj[key] !== 'undefined')

--- a/test/fixtures/operation-security-overriding-api-wide-security/output.js
+++ b/test/fixtures/operation-security-overriding-api-wide-security/output.js
@@ -21,8 +21,7 @@ function createApi(options) {
     }
     throw new Error('No security scheme was fulfilled by the provided securityHandlers for operation ' + operationId);
   };
-  const ensureRequiredSecurityHandlersExist = () => {
-    let requiredSecurityHandlers = ['api_wide_auth','petstore_auth'];
+  const ensureRequiredSecurityHandlersExist = (requiredSecurityHandlers) => {
     for (let i = 0, ilen = requiredSecurityHandlers.length; i < ilen; i++) {
       let requiredSecurityHandler = requiredSecurityHandlers[i];
       if (typeof securityHandlers[requiredSecurityHandler] !== 'function') {
@@ -31,7 +30,7 @@ function createApi(options) {
       }
     }
   };
-  ensureRequiredSecurityHandlersExist();
+  ensureRequiredSecurityHandlersExist(['api_wide_auth','petstore_auth']);
   const buildQuery = (obj) => {
     return Object.keys(obj)
       .filter(key => typeof obj[key] !== 'undefined')

--- a/test/fixtures/operation-security/output.js
+++ b/test/fixtures/operation-security/output.js
@@ -21,8 +21,7 @@ function createApi(options) {
     }
     throw new Error('No security scheme was fulfilled by the provided securityHandlers for operation ' + operationId);
   };
-  const ensureRequiredSecurityHandlersExist = () => {
-    let requiredSecurityHandlers = ['petstore_auth'];
+  const ensureRequiredSecurityHandlersExist = (requiredSecurityHandlers) => {
     for (let i = 0, ilen = requiredSecurityHandlers.length; i < ilen; i++) {
       let requiredSecurityHandler = requiredSecurityHandlers[i];
       if (typeof securityHandlers[requiredSecurityHandler] !== 'function') {
@@ -31,7 +30,7 @@ function createApi(options) {
       }
     }
   };
-  ensureRequiredSecurityHandlersExist();
+  ensureRequiredSecurityHandlersExist(['petstore_auth']);
   const buildQuery = (obj) => {
     return Object.keys(obj)
       .filter(key => typeof obj[key] !== 'undefined')


### PR DESCRIPTION
* Remove the direct inlining of security handlers for
  `ensureRequiredSecurityHandlersExist` in favor of function arguments

This is a thought on how to undo the difficult-to-read string concatenation for code generation, and instead leverage a few JS tricks to modularize some.